### PR TITLE
Support for Guzzle >5

### DIFF
--- a/Transport/MandrillTransport.php
+++ b/Transport/MandrillTransport.php
@@ -111,7 +111,9 @@ class MandrillTransport implements Swift_Transport {
 	 */
 	protected function getHttpClient()
 	{
-		return new Client;
+		return new Client(['defaults' => [
+			'verify' => false
+		]]);
 	}
 
 	/**


### PR DESCRIPTION
Guzzle 5 responds with an error message when a self-signed certificate is found. That is the case for mandrill:

"cURL error 60: SSL certificate problem: unable to get local issuer certificate..."

This fix wil ignore the verification of these certificates.