### PR TITLE
Make swiftmailer reconnect to support daemonized queues

### DIFF
--- a/Mailer.php
+++ b/Mailer.php
@@ -250,6 +250,9 @@ class Mailer implements MailerContract, MailQueueContract {
 	 */
 	public function handleQueuedMessage($job, $data)
 	{
+		// Stop and let swift automatically reconnect to support queue daemon mode
+		$this->getSwiftMailer()->getTransport()->stop();
+
 		$this->send($data['view'], $data['data'], $this->getQueuedCallable($data));
 
 		$job->delete();


### PR DESCRIPTION
when running the queue in daemon mode swift gives the error reported in the following ticket.
https://github.com/symfony/SwiftmailerBundle/issues/39
Fix has been tested and seems to work well