### PR TITLE
explicitly add catch after try block

### DIFF
--- a/Mailer.php
+++ b/Mailer.php
@@ -482,6 +482,8 @@ class Mailer implements MailerContract, MailQueueContract
     {
         try {
             return $this->swift->send($message, $this->failedRecipients);
+        catch (\Exception $e) {
+            // catch all exceptions
         } finally {
             $this->forceReconnection();
         }


### PR DESCRIPTION
tested under php7.3, when Swift_TransportException is thrown, without the catch block, error occurs:
![image](https://user-images.githubusercontent.com/641540/55212607-52ef5a00-522b-11e9-9cc3-d23671e4e856.png)
